### PR TITLE
customise how we work out which topics are repartitions

### DIFF
--- a/src/ktest/drivers/topology_driver.clj
+++ b/src/ktest/drivers/topology_driver.clj
@@ -188,9 +188,10 @@
         p (TopologyInternalsAccessor/processorTopology driver)
         gp (TopologyInternalsAccessor/globalProcessorTopology driver)
 
-        repartition-topic? (fn [topic]
-                             (or (when p (TopologyInternalsAccessor/isRepartitionTopic p topic))
-                                 (when gp (TopologyInternalsAccessor/isRepartitionTopic gp topic))))
+        repartition-topic? (or (:repartition-topic? opts)
+                               (fn [topic]
+                                 (or (when p (TopologyInternalsAccessor/isRepartitionTopic p topic))
+                                     (when gp (TopologyInternalsAccessor/isRepartitionTopic gp topic)))))
 
         p-sources (when p (.sourceTopics p))
         gp-sources (when gp (.sourceTopics gp))


### PR DESCRIPTION
In order for our hydration tests to work particularly, they need to be able to work out which topics are repartition ones. ktest currently does this by asking it if it's a repartition topic created by kafka, but in order to make our own repartition topics be treated the same (ie not cause a rehydration every time we process them), we need to be able to customise this behaviour