### PR TITLE
CCM-20653 Capture Kafka headers as metadata on test output values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.iml
 target/
 .lsp/
+.project
+.settings/

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,3 @@
+java temurin-17.0.19+10
+cljstyle 0.17.642
+clj-kondo 2025.10.23

--- a/deps.edn
+++ b/deps.edn
@@ -9,10 +9,10 @@
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
                                                           :sha "209b64504cb3bd3b99ecfec7937b358a879f55c1"}}
-                  :main-opts ["-m" "cognitect.test-runner"]}
-           :build {:extra-paths ["src-build"]
-                   :extra-deps {badigeon/badigeon {:mvn/version "1.1"}}
-                   :main-opts ["-m" "build"]}
+                  :main-opts ["-e" "(set! *warn-on-reflection* true)" "-m" "cognitect.test-runner"]}
+          :build {:extra-paths ["src-build"]
+                  :extra-deps {badigeon/badigeon {:mvn/version "1.1"}}
+                  :main-opts ["-e" "(set! *warn-on-reflection* true)" "-m" "build"]}
            :nREPL {:extra-deps
                     {nrepl/nrepl {:mvn/version "1.0.0"}
                      cider/piggieback {:mvn/version "0.4.2"}}}}}

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <packaging>jar</packaging>
   <groupId>djs</groupId>
   <artifactId>ktest</artifactId>
-  <version>3.9.2.1</version>
+  <version>3.9.2.2</version>
   <name>ktest</name>
   <dependencies>
     <dependency>

--- a/src/ktest/config.clj
+++ b/src/ktest/config.clj
@@ -1,7 +1,9 @@
 (ns ktest.config
   (:require [ktest.stores :as stores])
   (:import (java.util
-            Random)))
+            Random)
+           (org.apache.kafka.common.serialization
+            Serde)))
 
 (defn default-topology-mutator
   [topology _opts]
@@ -10,7 +12,7 @@
       stores/share-global-stores))
 
 (defn default-partition-strategy
-  [topic {:keys [key] :as msg} {:keys [key-serde]}]
+  [topic {:keys [key] :as _msg} {:keys [^Serde key-serde]}]
   (let [topic-name (if (string? topic) topic (:topic-name topic))]
     (->> key
          (.serialize (.serializer key-serde) topic-name)

--- a/src/ktest/core.clj
+++ b/src/ktest/core.clj
@@ -3,7 +3,7 @@
             [ktest.driver :refer [default-driver]]
             [ktest.protocols.batch-driver :as b]))
 
-(defn driver
+(defn ^ktest.protocols.batch_driver.BatchDriver driver
   [opts name-topology-supplier-map]
   {:pre [(or (nil? opts) (map? opts))
          (map? name-topology-supplier-map)

--- a/src/ktest/drivers/topology_driver.clj
+++ b/src/ktest/drivers/topology_driver.clj
@@ -3,14 +3,23 @@
             [ktest.internal.interop :as i]
             [ktest.protocols.driver :refer :all]
             [ktest.utils :refer :all])
-  (:import (java.time
+  (:import (clojure.lang
+            IObj)
+           (java.nio.charset
+            StandardCharsets)
+           (java.time
             Duration
             Instant)
+           (org.apache.kafka.clients.consumer
+            ConsumerRecord)
            (org.apache.kafka.common
             TopicPartition)
            (org.apache.kafka.common.header
             Header)
+           (org.apache.kafka.common.serialization
+            Serde)
            (org.apache.kafka.streams
+            KeyValue
             TopologyInternalsAccessor
             TopologyTestDriver)
            (org.apache.kafka.streams.processor
@@ -18,7 +27,11 @@
            (org.apache.kafka.streams.processor.internals
             StreamTask)
            (org.apache.kafka.streams.state
-            ValueAndTimestamp)))
+            KeyValueIterator
+            KeyValueStore
+            ValueAndTimestamp)
+           (org.apache.kafka.streams.test
+            TestRecord)))
 
 (defn- raw-repartition-topic
   [application-id topic]
@@ -29,47 +42,42 @@
 (defn- default-capture
   [application-id allow-first? source? repartition-topic? repartitions]
   (let [first-time? (atom allow-first?)]
-    (fn [^StreamTask delegate ^TopicPartition topic-partition message]
+    (fn [^StreamTask delegate ^TopicPartition topic-partition ^ConsumerRecord message]
       (let [[first-time? _] (reset-vals! first-time? false)
             topic (.topic topic-partition)]
         (cond
-          ;; the first time we see something, it's the thing we just manually
-          ;; sent in, so let it through!
           first-time? (.addRecords delegate topic-partition [message])
 
-          ;; if it's a repartition topic we should make sure we direct this to
-          ;; the same topology but on the correct partition so capture it
           (repartition-topic? topic) (swap! repartitions
                                             conj
                                             {(raw-repartition-topic application-id topic)
                                              [{:key (.key message)
                                                :value (.value message)}]})
 
-          ;; any time we hit a source except the first time, the topology
-          ;; driver will also say this is an output so don't do anything
-          ;; otherwise we'll collect it twice
           (source? topic) nil
 
-          ;; else it is an internal topic that doesn't cause a repartition, so
-          ;; let it go through the current topology
           :else (.addRecords delegate topic-partition [message]))))))
 
 (defn- headers->map
   [headers]
-  (->> headers
-       (map (fn [^Header h]
-              [(.key h) (when-let [v (.value h)] (String. v))]))
-       (into {})))
+  (reduce (fn [m ^Header h]
+            (let [k (.key h)]
+              (when (contains? m k)
+                (binding [*out* *err*]
+                  (println "WARN: duplicate Kafka header key:" k)))
+              (assoc m k (when-let [v (.value h)] (String. v StandardCharsets/UTF_8)))))
+          {}
+          headers))
 
 (defn- read-exhaustively
-  [^TopologyTestDriver driver sink opts]
-  (->> (.createOutputTopic driver sink (.deserializer (:key-serde opts)) (.deserializer (:value-serde opts)))
+  [^TopologyTestDriver driver sink {:keys [^Serde key-serde ^Serde value-serde]}]
+  (->> (.createOutputTopic driver sink (.deserializer key-serde) (.deserializer value-serde))
        (.readRecordsToList)
-       (map (fn [record]
+       (map (fn [^TestRecord record]
               (let [value (.value record)
                     hdrs (headers->map (.headers record))
-                    value (if (and (seq hdrs) (some? value) (instance? clojure.lang.IObj value))
-                            (with-meta value {:kafka-headers hdrs})
+                    value (if (and (seq hdrs) (some? value) (instance? IObj value))
+                            (vary-meta value assoc :kafka-headers hdrs)
                             value)]
                 {sink [{:key (.key record) :value value}]})))))
 
@@ -79,12 +87,10 @@
        (mapcat #(read-exhaustively driver % opts))))
 
 (defn- deserialize-msg
-  [opts topic msg]
-  (let [key-deserilizer (.deserializer (:key-serde opts))
-        value-deserilizer (.deserializer (:value-serde opts))]
-    (-> msg
-        (update :key #(.deserialize key-deserilizer topic %))
-        (update :value #(.deserialize value-deserilizer topic %)))))
+  [{:keys [^Serde key-serde ^Serde value-serde]} topic msg]
+  (-> msg
+      (update :key #(.deserialize (.deserializer key-serde) topic %))
+      (update :value #(.deserialize (.deserializer value-serde) topic %))))
 
 (defn- form-output
   [^TopologyTestDriver driver root-application-id sinks repartitions opts]
@@ -117,20 +123,20 @@
     :else nil))
 
 (defn extra-info-from-store
-  [state-store]
+  [^KeyValueStore state-store]
   (->> (.all state-store)
        (iterator-seq)
-       (reduce (fn [result key-value]
+       (reduce (fn [result ^KeyValue key-value]
                  (let [v (.value key-value)
                        v (if (instance? ValueAndTimestamp v)
-                           (.value v)
+                           (.value ^ValueAndTimestamp v)
                            v)]
                    (assoc result (.key key-value) v))) {})))
 
 (defrecord TopologyDriver
   [opts state ^TopologyTestDriver driver
    root-application-id application-id partition-id
-   sources sinks repartition-topic? key-serde value-serde]
+   sources sinks repartition-topic? ^Serde key-serde ^Serde value-serde]
 
   Driver
 
@@ -185,7 +191,7 @@
       {:topology r
        :config {}})))
 
-(defn driver
+(defn ^ktest.protocols.driver.Driver driver
   [root-application-id partition-id topology-supplier opts]
   (let [initial-epoch (Instant/ofEpochMilli (:initial-ms opts))
         state (atom {:epoch (:initial-ms opts)})

--- a/src/ktest/drivers/topology_driver.clj
+++ b/src/ktest/drivers/topology_driver.clj
@@ -8,6 +8,8 @@
             Instant)
            (org.apache.kafka.common
             TopicPartition)
+           (org.apache.kafka.common.header
+            Header)
            (org.apache.kafka.streams
             TopologyInternalsAccessor
             TopologyTestDriver)
@@ -52,11 +54,24 @@
           ;; let it go through the current topology
           :else (.addRecords delegate topic-partition [message]))))))
 
+(defn- headers->map
+  [headers]
+  (->> headers
+       (map (fn [^Header h]
+              [(.key h) (when-let [v (.value h)] (String. v))]))
+       (into {})))
+
 (defn- read-exhaustively
   [^TopologyTestDriver driver sink opts]
   (->> (.createOutputTopic driver sink (.deserializer (:key-serde opts)) (.deserializer (:value-serde opts)))
        (.readRecordsToList)
-       (map #(do {sink [{:key (.key %) :value (.value %)}]}))))
+       (map (fn [record]
+              (let [value (.value record)
+                    hdrs (headers->map (.headers record))
+                    value (if (and (seq hdrs) (some? value) (instance? clojure.lang.IObj value))
+                            (with-meta value {:kafka-headers hdrs})
+                            value)]
+                {sink [{:key (.key record) :value value}]})))))
 
 (defn- collect-outputs
   [^TopologyTestDriver driver sinks opts]

--- a/src/ktest/internal/interop.clj
+++ b/src/ktest/internal/interop.clj
@@ -16,9 +16,9 @@
             StreamTask)))
 
 (defn- properties
-  [p]
+  ^Properties [p]
   (reduce-kv
-   (fn [p k v]
+   (fn [^Properties p k v]
      (doto p
        (.setProperty (name k) v)))
    (Properties.)

--- a/src/ktest/stores.clj
+++ b/src/ktest/stores.clj
@@ -1,6 +1,9 @@
 (ns ktest.stores
-  (:import (java.util
-            List)
+  (:import (java.lang.reflect
+            Field)
+           (java.util
+            List
+            Map)
            (org.apache.kafka.common.serialization
             Serializer)
            (org.apache.kafka.common.utils
@@ -43,13 +46,13 @@
             ValueAndTimestampSerde
             WrappedStateStore)))
 
-(def ^:private global-state-builders-field
-  (let [f (.getDeclaredField InternalTopologyBuilder "globalStateBuilders")]
+(def ^:private ^Field global-state-builders-field
+  (let [^Field f (.getDeclaredField InternalTopologyBuilder "globalStateBuilders")]
     (.setAccessible f true)
     f))
 
-(def ^:private store-factory-builder-field
-  (let [f (.getDeclaredField StoreBuilderWrapper "builder")]
+(def ^:private ^Field store-factory-builder-field
+  (let [^Field f (.getDeclaredField StoreBuilderWrapper "builder")]
     (.setAccessible f true)
     f))
 
@@ -103,53 +106,53 @@
      sb
      (fn []
        (when-not (and @inner-store
-                      (.isOpen @inner-store))
+                      (.isOpen ^StateStore @inner-store))
          (reset! inner-store (.build sb)))
        (cond
          (isa? (type @inner-store) TimestampedKeyValueStore)
          (proxy [WrappedStateStore TimestampedKeyValueStore CachedStateStore]
                 [@inner-store]
            (^void init [^ProcessorContext v1 ^StateStore v2]
-             (if (.isOpen @inner-store)
+             (if (.isOpen ^StateStore @inner-store)
                (.register v1 this (reify StateRestoreCallback
                                     (restore [_this _a _b])))
-               (.init @inner-store v1 v2)))
+               (.init ^TimestampedKeyValueStore @inner-store v1 v2)))
 
-           (flush [] (.flush @inner-store))
+           (flush [] (.flush ^TimestampedKeyValueStore @inner-store))
 
-           (close [] (.close @inner-store))
+           (close [] (.close ^TimestampedKeyValueStore @inner-store))
 
-           (persistent [] (.persistent @inner-store))
+           (persistent [] (.persistent ^StateStore @inner-store))
 
-           (isOpen [] (.isOpen @inner-store))
+           (isOpen [] (.isOpen ^StateStore @inner-store))
 
-           (name [] (.name @inner-store))
+           (name [] (.name ^StateStore @inner-store))
 
-           (get [k] (.get @inner-store k))
+           (get [k] (.get ^TimestampedKeyValueStore @inner-store k))
 
-           (range [k1 k2] (.range @inner-store k1 k2))
+           (range [k1 k2] (.range ^TimestampedKeyValueStore @inner-store k1 k2))
 
-           (reverseRange [k1 k2] (.reverseRange @inner-store k1 k2))
+           (reverseRange [k1 k2] (.reverseRange ^TimestampedKeyValueStore @inner-store k1 k2))
 
-           (all [] (.all @inner-store))
+           (all [] (.all ^TimestampedKeyValueStore @inner-store))
 
-           (prefixScan [v1 v2] (.prefixScan @inner-store v1 v2))
+           (prefixScan [v1 v2] (.prefixScan ^TimestampedKeyValueStore @inner-store v1 v2))
 
-           (put [k v] (.put @inner-store k v))
+           (put [k v] (.put ^TimestampedKeyValueStore @inner-store k v))
 
-           (putIfAbsent [k v] (.putIfAbsent @inner-store k v))
+           (putIfAbsent [k v] (.putIfAbsent ^TimestampedKeyValueStore @inner-store k v))
 
-           (^void putAll [^List kvs] (.putAll @inner-store kvs))
+           (^void putAll [^List kvs] (.putAll ^TimestampedKeyValueStore @inner-store kvs))
 
-           (delete [k] (.delete @inner-store k))
+           (delete [k] (.delete ^TimestampedKeyValueStore @inner-store k))
 
-           (approximateNumEntries [] (.approximateNumEntries @inner-store))
+           (approximateNumEntries [] (.approximateNumEntries ^TimestampedKeyValueStore @inner-store))
 
            (setFlushListener [listener, send-old-values] (.setFlushListener ^WrappedStateStore @inner-store listener send-old-values))
 
-           (flushCache [] (.flushCache @inner-store))
+           (flushCache [] (.flushCache ^CachedStateStore @inner-store))
 
-           (clearCache [] (.clearCache @inner-store))
+           (clearCache [] (.clearCache ^CachedStateStore @inner-store))
 
            (wrapped [] (do @inner-store)))
 
@@ -157,58 +160,58 @@
          (proxy [WrappedStateStore KeyValueStore CachedStateStore StateStore ReadOnlyKeyValueStore]
                 [@inner-store]
 
-           (delete [o] (.delete @inner-store o))
+           (delete [o] (.delete ^KeyValueStore @inner-store o))
 
-           (^void put [o1 o2] (.put @inner-store o1 o2))
+           (^void put [o1 o2] (.put ^KeyValueStore @inner-store o1 o2))
 
-           (^void putAll [^List kvs] (.putAll @inner-store kvs))
+           (^void putAll [^List kvs] (.putAll ^KeyValueStore @inner-store kvs))
 
-           (putIfAbsent [o1 o2] (.putIfAbsent @inner-store o1 o2))
+           (putIfAbsent [o1 o2] (.putIfAbsent ^KeyValueStore @inner-store o1 o2))
 
-           (^String name [] (.name @inner-store))
+           (^String name [] (.name ^StateStore @inner-store))
 
            (^void init [^StateStoreContext ctx ^StateStore s]
-             (if (.isOpen @inner-store)
+             (if (.isOpen ^StateStore @inner-store)
                (.register ctx this (reify StateRestoreCallback
                                      (restore [_this _a _b])))
-               (.init @inner-store ctx s)))
+               (.init ^KeyValueStore @inner-store ctx s)))
 
-           (^void flush [] (.flush @inner-store))
+           (^void flush [] (.flush ^StateStore @inner-store))
 
-           (^void close [] (.close @inner-store))
+           (^void close [] (.close ^StateStore @inner-store))
 
-           (^boolean persistent [] (.persistent @inner-store))
+           (^boolean persistent [] (.persistent ^StateStore @inner-store))
 
-           (^boolean isOpen [] (.isOpen @inner-store))
+           (^boolean isOpen [] (.isOpen ^StateStore @inner-store))
 
            (^QueryResult query [^Query query ^PositionBound position-bound ^QueryConfig query-config]
-             (.query @inner-store query position-bound query-config))
+             (.query ^StateStore @inner-store query position-bound query-config))
 
-           (^Position getPosition [] (.getPosition @inner-store))
+           (^Position getPosition [] (.getPosition ^StateStore @inner-store))
 
-           (get [o] (.get @inner-store o))
+           (get [o] (.get ^KeyValueStore @inner-store o))
 
-           (^KeyValueIterator range [o1 o2] (.range @inner-store o1 o2))
+           (^KeyValueIterator range [o1 o2] (.range ^KeyValueStore @inner-store o1 o2))
 
-           (^KeyValueIterator reverseRange [o1 o2] (.reverseRange @inner-store o1 o2))
+           (^KeyValueIterator reverseRange [o1 o2] (.reverseRange ^KeyValueStore @inner-store o1 o2))
 
-           (^KeyValueIterator all [] (.all @inner-store))
+           (^KeyValueIterator all [] (.all ^KeyValueStore @inner-store))
 
-           (^KeyValueIterator reverseAll [] (.reverseAll @inner-store))
+           (^KeyValueIterator reverseAll [] (.reverseAll ^KeyValueStore @inner-store))
 
            (^KeyValueIterator prefixScan [o ^Serializer serializer]
-             (.prefixScan @inner-store o serializer))
+             (.prefixScan ^KeyValueStore @inner-store o serializer))
 
            (^long approximateNumEntries []
-             (.approximateNumEntries @inner-store))
+             (.approximateNumEntries ^KeyValueStore @inner-store))
 
            (setFlushListener
              [^CacheFlushListener listener b]
-             (.setFlushListener @inner-store listener b))
+             (.setFlushListener ^MeteredKeyValueStore @inner-store listener b))
 
-           (^void clearCache [] (.clearCache @inner-store))
+           (^void clearCache [] (.clearCache ^CachedStateStore @inner-store))
 
-           (^void flushCache [] (.flushCache @inner-store))
+           (^void flushCache [] (.flushCache ^CachedStateStore @inner-store))
 
            (wrapped [] @inner-store))
          :else
@@ -261,7 +264,7 @@
   store-factory)
 
 (defmethod find-store-factory-alternative StoreBuilderWrapper
-  [store-factory store-name]
+  [^StoreBuilderWrapper store-factory store-name]
   (-> (.get store-factory-builder-field store-factory)
       (find-store-builder-alternative store-name)
       (StoreBuilderWrapper.)))
@@ -285,13 +288,13 @@
 
 (defn alternative-store
   [store-name ^StoreFactory state-store-factory]
-  (-> (find-store-factory-alternative state-store-factory store-name)
-      (.withLoggingDisabled)))
+  (let [^StoreFactory alt (find-store-factory-alternative state-store-factory store-name)]
+    (.withLoggingDisabled alt)))
 
 (defn share-global-stores
   [topology]
   (let [i-builder (TopologyInternalsAccessor/internalTopologyBuilder topology)
-        global-store-builders (.get global-state-builders-field i-builder)]
+        ^Map global-store-builders (.get global-state-builders-field i-builder)]
     (doseq [[n sb] global-store-builders]
       (when-not (isa? (type sb) SingletonStoreFactory)
         (.put global-store-builders n (singleton-store-builder sb)))))

--- a/test/ktest/core_test.clj
+++ b/test/ktest/core_test.clj
@@ -4,6 +4,9 @@
             [ktest.test-utils :as j])
   (:import (java.time
             Duration)
+           (org.apache.kafka.streams
+            KeyValue
+            StreamsBuilder)
            (org.apache.kafka.streams.processor
             ProcessorContext)
            (org.apache.kafka.streams.state
@@ -115,7 +118,7 @@
 (defn transform-topology
   []
   (let [builder (j/streams-builder)]
-    (.addStateStore builder
+    (.addStateStore ^StreamsBuilder builder
                     (Stores/keyValueStoreBuilder
                      (Stores/persistentKeyValueStore "trans-store")
                      j/edn-serde j/edn-serde))
@@ -135,7 +138,7 @@
 (defn select-key-transform-topology
   []
   (let [builder (j/streams-builder)]
-    (.addStateStore builder
+    (.addStateStore ^StreamsBuilder builder
                     (Stores/keyValueStoreBuilder
                      (Stores/persistentKeyValueStore "trans-store")
                      j/edn-serde j/edn-serde))
@@ -156,7 +159,7 @@
 (defn repartition-transform-topology
   []
   (let [builder (j/streams-builder)]
-    (.addStateStore builder
+    (.addStateStore ^StreamsBuilder builder
                     (Stores/keyValueStoreBuilder
                      (Stores/persistentKeyValueStore "trans-store")
                      j/edn-serde j/edn-serde))
@@ -275,7 +278,7 @@
   (let [builder (j/streams-builder)]
     (-> (j/kstream builder (j/topic-config "time-input"))
         (j/transform
-         (j/punctuator (Duration/ofMillis 1) (fn [ctx epoch]
+         (j/punctuator (Duration/ofMillis 1) (fn [^ProcessorContext ctx epoch]
                                                (.forward ctx "k" (str "v at " epoch)))))
         (j/to (j/topic-config "time-output")))
     (j/build-topology builder)))
@@ -433,7 +436,7 @@
              (sut/pipe driver "join-input" {:key "k" :value "global-key"}))))))
 
 (defn get-from-store
-  [ctx store-name k]
+  [^ProcessorContext ctx store-name k]
   (let [^KeyValueStore store (.getStateStore ctx store-name)
         ^ValueAndTimestamp vt (.get store k)]
     (when vt (.value vt))))
@@ -450,7 +453,7 @@
     (-> (j/kstream builder (j/topic-config "empty"))
         (j/transform
          (j/punctuator (Duration/ofMillis 1)
-                       (fn [ctx timestamp]
+                       (fn [^ProcessorContext ctx timestamp]
                          (when-let [t1-value (get-from-store ctx "trigger-1-store" "key")]
                            (.forward ctx
                                      "key"
@@ -468,7 +471,7 @@
     (-> (j/kstream builder (j/topic-config "empty"))
         (j/transform
          (j/punctuator (Duration/ofMillis 1)
-                       (fn [ctx timestamp]
+                       (fn [^ProcessorContext ctx timestamp]
                          (when-let [t1-map (get-from-store ctx "trigger-2-store" "key")]
                            (.forward ctx
                                      "key"
@@ -527,14 +530,14 @@
 
 (defn store-by-range-key
   [^ProcessorContext ctx store-name foreign-key original-key original-value]
-  (let [store (.getStateStore ctx store-name)
+  (let [^KeyValueStore store (.getStateStore ctx store-name)
         k (within-range-key foreign-key original-key)]
     (.put store k original-value)))
 
 (defn range-topology
   []
   (let [builder (j/streams-builder)]
-    (.addStateStore builder
+    (.addStateStore ^StreamsBuilder builder
                     (Stores/keyValueStoreBuilder
                      (Stores/persistentKeyValueStore "trans-store")
                      j/edn-serde j/edn-serde))
@@ -550,7 +553,7 @@
          (j/transformer
           (fn [^ProcessorContext ctx k v]
             (let [^KeyValueStore store (.getStateStore ctx "trans-store")]
-              (doseq [kv-java (iterator-seq (.range store (before-range-key k) (after-range-key k)))]
+              (doseq [^KeyValue kv-java (iterator-seq (.range store (before-range-key k) (after-range-key k)))]
                 (.forward ctx (.key kv-java) (.value kv-java))))))
          ["trans-store"])
         (j/to (j/topic-config "output")))

--- a/test/ktest/drivers/topology_driver_test.clj
+++ b/test/ktest/drivers/topology_driver_test.clj
@@ -4,7 +4,9 @@
             [ktest.drivers.topology-driver :as sut]
             [ktest.protocols.driver :as driver]
             [ktest.test-utils :as j])
-  (:import (org.apache.kafka.common.header.internals
+  (:import (java.nio.charset
+            StandardCharsets)
+           (org.apache.kafka.common.header.internals
             RecordHeader)
            (org.apache.kafka.streams.processor.api
             FixedKeyRecord)))
@@ -99,7 +101,7 @@
     (-> (j/kstream builder (j/topic-config "input"))
         (j/process-values
          (fn [^FixedKeyRecord record]
-           (.add (.headers record) (RecordHeader. "audit.test" (.getBytes "hello")))))
+           (.add (.headers record) (RecordHeader. "audit.test" (.getBytes "hello" StandardCharsets/UTF_8)))))
         (j/to (j/topic-config "output")))
     (j/build-topology builder)))
 

--- a/test/ktest/drivers/topology_driver_test.clj
+++ b/test/ktest/drivers/topology_driver_test.clj
@@ -3,7 +3,11 @@
             [ktest.config :refer [mk-opts]]
             [ktest.drivers.topology-driver :as sut]
             [ktest.protocols.driver :as driver]
-            [ktest.test-utils :as j]))
+            [ktest.test-utils :as j])
+  (:import (org.apache.kafka.common.header.internals
+             RecordHeader)
+           (org.apache.kafka.streams.processor.api
+             FixedKeyRecord)))
 
 (def opts (mk-opts j/serde-config))
 
@@ -88,3 +92,24 @@
                                  topology-with-store-not-used
                                  opts)]
     (driver/stores-info driver)))
+
+(defn header-setting-topology
+  []
+  (let [builder (j/streams-builder)]
+    (-> (j/kstream builder (j/topic-config "input"))
+        (j/process-values
+         (fn [^FixedKeyRecord record]
+           (.add (.headers record) (RecordHeader. "audit.test" (.getBytes "hello")))))
+        (j/to (j/topic-config "output")))
+    (j/build-topology builder)))
+
+(deftest headers-captured-as-metadata
+  (with-open [driver (sut/driver "application-id"
+                                 "partition-id"
+                                 header-setting-topology
+                                 opts)]
+    (let [result (driver/pipe-input driver "input" {:key "k" :value {:foo "bar"}})
+          output-value (-> result (get "output") first :value)]
+      (is (= {:foo "bar"} output-value))
+      (is (= {"audit.test" "hello"}
+             (:kafka-headers (meta output-value)))))))

--- a/test/ktest/drivers/topology_driver_test.clj
+++ b/test/ktest/drivers/topology_driver_test.clj
@@ -5,9 +5,9 @@
             [ktest.protocols.driver :as driver]
             [ktest.test-utils :as j])
   (:import (org.apache.kafka.common.header.internals
-             RecordHeader)
+            RecordHeader)
            (org.apache.kafka.streams.processor.api
-             FixedKeyRecord)))
+            FixedKeyRecord)))
 
 (def opts (mk-opts j/serde-config))
 

--- a/test/ktest/test_utils.clj
+++ b/test/ktest/test_utils.clj
@@ -101,7 +101,7 @@
 
 (defn add-store
   [store]
-  (.addStateStore (streams-builder) (Stores/keyValueStoreBuilder (Stores/persistentKeyValueStore store) nil nil)))
+  (.addStateStore ^StreamsBuilder (streams-builder) (Stores/keyValueStoreBuilder (Stores/persistentKeyValueStore store) nil nil)))
 
 (defn ktable
   ([builder topic-config store-name]
@@ -202,25 +202,25 @@
                                 (.withValueSerde (:value-serde store-config)))))
 
 (defn group-by-key
-  ([stream]
+  ([^KStream stream]
    (.groupByKey stream))
-  ([stream serde-config]
+  ([^KStream stream serde-config]
    (.groupByKey stream (Grouped/with (:key-serde serde-config)
                                      (:value-serde serde-config)))))
 
 (defn to-kstream
-  [ktable]
+  [^KTable ktable]
   (.toStream ktable))
 
 (defn transform
-  ([stream transformer-supplier-fn stores]
+  ([^KStream stream transformer-supplier-fn stores]
    (.transform stream
                (reify TransformerSupplier
                  (get
                    [_]
                    (transformer-supplier-fn)))
                (into-array String stores)))
-  ([stream transformer-supplier-fn]
+  ([^KStream stream transformer-supplier-fn]
    (.transform stream
                (reify TransformerSupplier
                  (get

--- a/test/ktest/test_utils.clj
+++ b/test/ktest/test_utils.clj
@@ -148,12 +148,16 @@
   [^KStream kstream f]
   (.processValues kstream
                   (reify FixedKeyProcessorSupplier
-                    (get [_]
+                    (get
+                      [_]
                       (let [ctx (atom nil)]
                         (reify FixedKeyProcessor
-                          (init [_ context]
+                          (init
+                            [_ context]
                             (reset! ctx context))
-                          (process [_ record]
+
+                          (process
+                            [_ record]
                             (f record)
                             (.forward ^FixedKeyProcessorContext @ctx record))))))
                   (into-array String [])))

--- a/test/ktest/test_utils.clj
+++ b/test/ktest/test_utils.clj
@@ -36,6 +36,11 @@
             PunctuationType
             Punctuator
             To)
+           (org.apache.kafka.streams.processor.api
+            FixedKeyProcessor
+            FixedKeyProcessorContext
+            FixedKeyProcessorSupplier
+            FixedKeyRecord)
            (org.apache.kafka.streams.state
             Stores)))
 
@@ -139,6 +144,19 @@
               ^ValueJoiner (reify ValueJoiner
                              (apply [_ a b] (joiner-fn a b))))))
 
+(defn process-values
+  [^KStream kstream f]
+  (.processValues kstream
+                  (reify FixedKeyProcessorSupplier
+                    (get [_]
+                      (let [ctx (atom nil)]
+                        (reify FixedKeyProcessor
+                          (init [_ context]
+                            (reset! ctx context))
+                          (process [_ record]
+                            (f record)
+                            (.forward ^FixedKeyProcessorContext @ctx record))))))
+                  (into-array String [])))
 (defn to
   [kstream topic-config]
   (.to ^KStream kstream


### PR DESCRIPTION
Captures Kafka message headers as `:kafka-headers` metadata on output record values in ktest, enabling topology tests to assert on headers set by FixedKeyProcessors.