### PR TITLE
Add send-side header support, fix deps.edn aliases, bump dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,137 @@
+# ktest
+
+Clojure library for unit-testing Kafka Streams topologies with partition-aware, deterministic execution. Wraps `TopologyTestDriver` with a layered driver stack that simulates multi-partition behaviour, repartitioning, and optional message shuffling.
+
+## Build and Test
+
+Java classes in `src-java/` **must** be compiled before any Clojure code can load:
+
+```sh
+clj -M:build                                    # compile Java classes (required before REPL or tests)
+clj -M:test:run-tests                            # run all tests
+clj -M:test:run-tests -v ktest.core-test/simple  # run a single test
+./test.sh                                        # compile Java + run tests (standard workflow)
+```
+
+Any change to Java sources in `src-java/` requires `clj -M:build` and a REPL restart.
+
+### Aliases
+
+`:test` provides test classpath (paths + deps) without a runner. `:run-tests` provides the runner main-opts. They compose freely with `:nREPL`:
+
+| What | Command |
+|---|---|
+| Run tests | `clj -M:test:run-tests` |
+| Single test | `clj -M:test:run-tests -v ns/test` |
+| REPL + test classpath | `clj -M:test:nREPL` |
+| REPL (no tests) | `clj -M:nREPL` |
+| Build Java | `clj -M:build` |
+
+### Protocol reload
+
+The `Driver` protocol and its record implementations span multiple namespaces. Reloading a single driver namespace (e.g. `topology-driver`) without reloading the protocol causes `ClassCastException` due to classloader mismatch. Reload the full chain:
+
+```clojure
+(require '[ktest.protocols.driver :refer :all] :reload
+         '[ktest.drivers.topology-driver] :reload
+         '[ktest.drivers.completing-internals-driver] :reload
+         '[ktest.drivers.combined-driver] :reload
+         '[ktest.drivers.partitioned-driver] :reload
+         '[ktest.core] :reload)
+```
+
+## Formatting and Linting
+
+- `cljstyle` (config: `.cljstyle`); `:list-indent 1`
+- `clj-kondo`
+- Versions pinned in `.tool-versions` (asdf)
+
+## Release Workflow
+
+- `install.sh $VERSION`: updates pom version, compiles Java, builds jar via depstar, installs to local Maven
+- `deploy.sh $VERSION`: runs `install.sh`, tags the commit, pushes tags, deploys jar to Clojars
+- `pom.xml` is generated/updated by `clj -Spom`; don't edit manually except via `mvn versions:set`
+
+## Architecture
+
+### Public API
+
+`ktest.core` is the only public namespace. Everything else is internal. Key functions:
+- `driver` creates a `BatchDriver` from an options map and a `{name topology-supplier-fn}` map
+- `pipe` / `pipe-many` send messages; return `{topic-name [{:key k :value v}]}`
+- `advance-time` / `set-time` control wall-clock for punctuators
+- `stores-info` reads current state store contents
+
+### Driver Stack
+
+Assembled in `ktest.driver/default-driver`. Each layer wraps the one below, adding one concern:
+
+```mermaid
+graph TD
+    A[CleaningBatchDriver<br/>strips internal metadata from output] --> B
+    B[RecursionDriver<br/>feeds output back as input until quiescent<br/>conditional: recurse option] --> C
+    C[ShuffleDriver<br/>randomly reorders cross-partition messages<br/>conditional: shuffle option] --> D
+    D[BatchUpDriver<br/>adapts Driver protocol to BatchDriver] --> E
+    E[CombiningDriver<br/>fans input to all topology instances] --> F
+    F[CompletingInternalsDriver<br/>loops repartition messages until settled] --> G
+    G[PartitioningDriver<br/>one TopologyDriver per partition key<br/>partition key = MD5 hash via digest lib] --> H
+    H[TopologyDriver<br/>wraps TopologyTestDriver<br/>intercepts repartition + source messages via CapturingStreamTask]
+```
+
+Two protocols:
+- `ktest.protocols.driver/Driver`: single-message `pipe-input`
+- `ktest.protocols.batch-driver/BatchDriver`: batch `pipe-inputs`
+
+### Message Flow
+
+Shows how input messages are processed and how the two feedback loops operate:
+
+```mermaid
+flowchart TD
+    Input[/"pipe / pipe-many"/] --> Clean[CleaningBatchDriver]
+    Clean --> Recurse{RecursionDriver}
+    Recurse --> Shuffle[ShuffleDriver]
+    Shuffle --> Batch[BatchUpDriver]
+    Batch --> Combine[CombiningDriver]
+    Combine --> Complete{CompletingInternalsDriver}
+    Complete --> Partition[PartitioningDriver]
+    Partition --> Topo[TopologyDriver]
+
+    Topo --> TopoOut{output type?}
+    TopoOut -->|repartition msgs| RepartLoop["feed back into PartitioningDriver\n(may land on different partition)"]
+    RepartLoop --> Partition
+    TopoOut -->|normal output| Complete
+
+    Complete -->|settled| Combine
+    Combine --> Batch
+    Batch --> Shuffle
+    Shuffle --> Recurse
+
+    Recurse -->|output has messages| RecurseLoop["feed output back as new input\n(enables cross-topology chaining)"]
+    RecurseLoop --> Recurse
+    Recurse -->|no more output| Clean
+    Clean --> Output[/"{topic [{:key k :value v}]}"/]
+```
+
+### Java Interop Layer
+
+`src-java/` contains classes placed in Kafka's own packages to access package-private internals:
+- `CapturingStreamTask`: wraps `StreamTask`, intercepts `addRecords` via a Clojure `IFn` delegate
+- `TopologyInternalsAccessor`, `ProcessorTopologyAccessor`, `StoreAccessor`, `MaterializedStoreFactoryAccessor`: public accessors for internal fields
+
+These are **tightly coupled to the Kafka Streams version** in `deps.edn`. Upgrading Kafka will likely require updating them.
+
+## Key Conventions
+
+- Topology suppliers can return a `Topology` or a `{:topology t :config m}` map for custom Kafka config
+- Options map (`ktest.config/mk-opts`) flows through the entire stack; key options:
+  - `:key-serde` / `:value-serde`: serialisation (required)
+  - `:partition`: fn controlling mock partition assignment (default: serde round-trip of key)
+  - `:shuffle` / `:seed`: enable deterministic random reordering across partitions
+  - `:recurse` / `:recursion-limit` (default 1000): feed output back as input until quiescent
+  - `:topo-mutator`: hook to transform topology before test; default swaps stores to in-memory and shares global stores across partitions
+  - `:initial-ms`: starting wall-clock epoch (default 0)
+- Kafka message headers are captured as Clojure metadata (`:kafka-headers`) on output values
+- Tests use `with-open` on the driver (protocols include `close`)
+- `ktest.test-utils` (in `test/`, not published) provides Clojure wrappers around Kafka Streams builder API for constructing test topologies
+- `deps.edn` requires the Confluent Maven repo (`packages.confluent.io`) for Kafka dependencies

--- a/deps.edn
+++ b/deps.edn
@@ -1,18 +1,18 @@
 {:paths ["src" "target/classes"]
- :deps {org.clojure/clojure {:mvn/version "1.10.1"}
+ :deps {org.clojure/clojure {:mvn/version "1.12.5"}
         org.apache.kafka/kafka-streams {:mvn/version "7.9.2-ccs"}
         org.apache.kafka/kafka-streams-test-utils {:mvn/version "7.9.2-ccs"}
-        digest/digest {:mvn/version "1.4.9"}}
+        digest/digest {:mvn/version "1.4.10"}}
  :mvn/repos {"confluent" {:url "https://packages.confluent.io/maven/"}
              "central" {:url "https://repo1.maven.org/maven2/"}
              "clojars" {:url "https://repo.clojars.org/"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
-                                                          :sha "209b64504cb3bd3b99ecfec7937b358a879f55c1"}}
-                  :main-opts ["-e" "(set! *warn-on-reflection* true)" "-m" "cognitect.test-runner"]}
+                                                         :sha "3f288f1f16d167723ad87cc35b1dfee3c1681e10"}}}
+          :run-tests {:main-opts ["-e" "(set! *warn-on-reflection* true)" "-m" "cognitect.test-runner"]}
           :build {:extra-paths ["src-build"]
-                  :extra-deps {badigeon/badigeon {:mvn/version "1.1"}}
-                  :main-opts ["-e" "(set! *warn-on-reflection* true)" "-m" "build"]}
-           :nREPL {:extra-deps
-                    {nrepl/nrepl {:mvn/version "1.0.0"}
-                     cider/piggieback {:mvn/version "0.4.2"}}}}}
+                 :extra-deps {badigeon/badigeon {:mvn/version "1.7"}}
+                 :main-opts ["-e" "(set! *warn-on-reflection* true)" "-m" "build"]}
+          :nREPL {:extra-deps {nrepl/nrepl {:mvn/version "1.7.0"}
+                              cider/piggieback {:mvn/version "0.6.1"}}
+                 :main-opts ["-m" "nrepl.cmdline"]}}}

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>clojure</artifactId>
-      <version>1.10.1</version>
+      <version>1.12.5</version>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>digest</groupId>
       <artifactId>digest</artifactId>
-      <version>1.4.9</version>
+      <version>1.4.10</version>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>

--- a/src/ktest/drivers/topology_driver.clj
+++ b/src/ktest/drivers/topology_driver.clj
@@ -3,9 +3,7 @@
             [ktest.internal.interop :as i]
             [ktest.protocols.driver :refer :all]
             [ktest.utils :refer :all])
-  (:import (clojure.lang
-            IObj)
-           (java.nio.charset
+  (:import (java.nio.charset
             StandardCharsets)
            (java.time
             Duration
@@ -16,6 +14,8 @@
             TopicPartition)
            (org.apache.kafka.common.header
             Header)
+           (org.apache.kafka.common.header.internals
+            RecordHeaders)
            (org.apache.kafka.common.serialization
             Serde)
            (org.apache.kafka.streams
@@ -39,6 +39,25 @@
     (subs topic (inc (count application-id)))
     (throw (ex-info "This method should only be called with a topologies repartition topics" {}))))
 
+(defn headers->map
+  [headers]
+  (reduce (fn [m ^Header h]
+            (let [k (.key h)]
+              (when (contains? m k)
+                (binding [*out* *err*]
+                  (println "WARN: duplicate Kafka header key:" k)))
+              (assoc m k (when-let [v (.value h)] (String. v StandardCharsets/UTF_8)))))
+          {}
+          headers))
+
+(defn map->headers
+  [header-map]
+  (when (not-empty header-map)
+    (let [headers (RecordHeaders.)]
+      (doseq [[k v] header-map]
+        (.add headers ^String k (when v (.getBytes ^String v StandardCharsets/UTF_8))))
+      headers)))
+
 (defn- default-capture
   [application-id allow-first? source? repartition-topic? repartitions]
   (let [first-time? (atom allow-first?)]
@@ -51,23 +70,13 @@
           (repartition-topic? topic) (swap! repartitions
                                             conj
                                             {(raw-repartition-topic application-id topic)
-                                             [{:key (.key message)
-                                               :value (.value message)}]})
+                                             [{:key     (.key message)
+                                               :value   (.value message)
+                                               :headers (headers->map (.headers message))}]})
 
           (source? topic) nil
 
           :else (.addRecords delegate topic-partition [message]))))))
-
-(defn- headers->map
-  [headers]
-  (reduce (fn [m ^Header h]
-            (let [k (.key h)]
-              (when (contains? m k)
-                (binding [*out* *err*]
-                  (println "WARN: duplicate Kafka header key:" k)))
-              (assoc m k (when-let [v (.value h)] (String. v StandardCharsets/UTF_8)))))
-          {}
-          headers))
 
 (defn- read-exhaustively
   [^TopologyTestDriver driver sink {:keys [^Serde key-serde ^Serde value-serde]}]
@@ -76,10 +85,10 @@
        (map (fn [^TestRecord record]
               (let [value (.value record)
                     hdrs (headers->map (.headers record))
-                    value (if (and (seq hdrs) (some? value) (instance? IObj value))
-                            (vary-meta value assoc :kafka-headers hdrs)
-                            value)]
-                {sink [{:key (.key record) :value value}]})))))
+                    msg {:key (.key record) :value value}]
+                {sink [(if (seq hdrs)
+                         (vary-meta msg assoc :kafka-headers hdrs)
+                         msg)]})))))
 
 (defn- collect-outputs
   [^TopologyTestDriver driver sinks opts]
@@ -151,7 +160,9 @@
                                       sources
                                       repartition-topic?
                                       repartitions))
-        (.pipeInput input-topic (:key message) (:value message))
+        (if-let [hdrs (map->headers (:headers message))]
+          (.pipeInput input-topic (TestRecord. (:key message) (:value message) ^org.apache.kafka.common.header.Headers hdrs))
+          (.pipeInput input-topic (:key message) (:value message)))
         (form-output driver root-application-id sinks @repartitions opts))))
 
 

--- a/test.sh
+++ b/test.sh
@@ -10,4 +10,4 @@ clj -Spom
 # generate java classes
 clj -M:build
 # run tests
-clj -M:test
+clj -M:test:run-tests

--- a/test/ktest/core_test.clj
+++ b/test/ktest/core_test.clj
@@ -247,6 +247,15 @@
                                         :v "v3"}]}]}
              (sut/pipe driver "trans-input" {:key "other" :value "v3"}))))))
 
+(deftest headers-survive-repartition
+  (with-open [driver (sut/driver j/serde-config
+                                 {"transform-repartition" repartition-transform-topology})]
+    (let [result (sut/pipe driver "trans-input" {:key     "k"
+                                                :value   {:data "v1"}
+                                                :headers {"trace-id" "abc-123"}})]
+      (is (= {"trace-id" "abc-123"}
+             (:kafka-headers (meta (first (get result "through")))))))))
+
 (defn first-connected-topology
   []
   (let [builder (j/streams-builder)]

--- a/test/ktest/drivers/topology_driver_test.clj
+++ b/test/ktest/drivers/topology_driver_test.clj
@@ -56,8 +56,9 @@
     (is (= {{:repartition true
              :application-id "application-id"
              :topic-name "KSTREAM-KEY-SELECT-0000000003-repartition"}
-            [{:key "constant"
-              :value "v1"}]}
+            [{:key     "constant"
+              :value   "v1"
+              :headers {}}]}
            (driver/pipe-input driver "stream-input" {:key "k" :value "v1"})))
 
     (is (= {"join-output" [{:key "constant"
@@ -71,6 +72,19 @@
                                :value "v1"})))
     (is (= {"table-input" {"partition-id" {"constant" "table1"}}}
            (driver/stores-info driver)))))
+
+(deftest headers-captured-in-repartition
+  (with-open [driver (sut/driver "application-id"
+                                 "partition-id"
+                                 repartition-transform-topology
+                                 opts)]
+    (driver/pipe-input driver "table-input" {:key "constant" :value "table1"})
+    (let [result (driver/pipe-input driver "stream-input"
+                                    {:key     "k"
+                                     :value   "v1"
+                                     :headers {"trace-id" "abc-123"}})]
+      (is (= {"trace-id" "abc-123"}
+             (-> result vals first first :headers))))))
 
 (defn topology-with-store-not-used
   []
@@ -105,13 +119,39 @@
         (j/to (j/topic-config "output")))
     (j/build-topology builder)))
 
+(deftest map->headers-round-trip
+  (is (= {"audit.event.id" "evt-1"
+           "audit.event.type" "party-create"
+           "nullable" nil}
+          (->> {"audit.event.id" "evt-1"
+                "audit.event.type" "party-create"
+                "nullable" nil}
+               (sut/map->headers)
+               (sut/headers->map))))
+  (is (nil? (sut/map->headers nil)))
+  (is (nil? (sut/map->headers {}))))
+
+(deftest headers-sent-on-input
+  (with-open [driver (sut/driver "application-id"
+                                 "partition-id"
+                                 very-simple-topology
+                                 opts)]
+    (let [result (driver/pipe-input driver "input"
+                                    {:key "k"
+                                     :value {:foo "bar"}
+                                     :headers {"audit.event.id" "evt-1"}})
+          output-msg (-> result (get "output") first)]
+      (is (= {:foo "bar"} (:value output-msg)))
+      (is (= {"audit.event.id" "evt-1"}
+             (:kafka-headers (meta output-msg)))))))
+
 (deftest headers-captured-as-metadata
   (with-open [driver (sut/driver "application-id"
                                  "partition-id"
                                  header-setting-topology
                                  opts)]
     (let [result (driver/pipe-input driver "input" {:key "k" :value {:foo "bar"}})
-          output-value (-> result (get "output") first :value)]
-      (is (= {:foo "bar"} output-value))
+          output-msg (-> result (get "output") first)]
+      (is (= {:foo "bar"} (:value output-msg)))
       (is (= {"audit.test" "hello"}
-             (:kafka-headers (meta output-value)))))))
+             (:kafka-headers (meta output-msg)))))))


### PR DESCRIPTION
## Summary
- Send-side Kafka header support
- Repartition header preservation
- Fixed deps.edn alias composition
- Bumped deps
- Added cross-tool AI agent instructions